### PR TITLE
Open in SoundCleod

### DIFF
--- a/SoundCleod.xcodeproj/project.pbxproj
+++ b/SoundCleod.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		3A6AE3A317613C9900D67ADC /* DHSwipeClipView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A6AE39E17613C9900D67ADC /* DHSwipeClipView.m */; };
 		3A6AE3A417613C9900D67ADC /* DHSwipeIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A6AE3A017613C9900D67ADC /* DHSwipeIndicator.m */; };
 		3A6AE3A517613C9900D67ADC /* DHSwipeWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A6AE3A217613C9900D67ADC /* DHSwipeWebView.m */; };
+		5D55928B19FE27A200552362 /* SCURLService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D55928A19FE27A200552362 /* SCURLService.m */; };
 		5DC7C72219D405D50007FE30 /* NSURL+SCUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DC7C72119D405D50007FE30 /* NSURL+SCUtils.m */; };
 /* End PBXBuildFile section */
 
@@ -83,6 +84,8 @@
 		3A6AE3A017613C9900D67ADC /* DHSwipeIndicator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DHSwipeIndicator.m; sourceTree = "<group>"; };
 		3A6AE3A117613C9900D67ADC /* DHSwipeWebView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DHSwipeWebView.h; sourceTree = "<group>"; };
 		3A6AE3A217613C9900D67ADC /* DHSwipeWebView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DHSwipeWebView.m; sourceTree = "<group>"; };
+		5D55928919FE27A200552362 /* SCURLService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCURLService.h; sourceTree = "<group>"; };
+		5D55928A19FE27A200552362 /* SCURLService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCURLService.m; sourceTree = "<group>"; };
 		5DC7C72019D405D50007FE30 /* NSURL+SCUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+SCUtils.h"; sourceTree = "<group>"; };
 		5DC7C72119D405D50007FE30 /* NSURL+SCUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+SCUtils.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -175,6 +178,8 @@
 				26FF31091680734B0091448C /* PopupController.m */,
 				2624EBA216A81FA100490144 /* UrlPromptController.h */,
 				2624EBA316A81FA100490144 /* UrlPromptController.m */,
+				5D55928919FE27A200552362 /* SCURLService.h */,
+				5D55928A19FE27A200552362 /* SCURLService.m */,
 				26FF311C168075A50091448C /* Resources */,
 				3A295063175FDF560038B28C /* SCDApplication.h */,
 				3A295064175FDF560038B28C /* SCDApplication.m */,
@@ -288,6 +293,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D55928B19FE27A200552362 /* SCURLService.m in Sources */,
 				26B5794C167A58CD0034D295 /* NSObject+SPInvocationGrabbing.m in Sources */,
 				26B5794D167A58CD0034D295 /* SPMediaKeyTap.m in Sources */,
 				26FF310C1680734B0091448C /* AppDelegate.m in Sources */,

--- a/SoundCleod/SCURLService.h
+++ b/SoundCleod/SCURLService.h
@@ -1,0 +1,24 @@
+//
+//  UrlService.h
+//  SoundCleod
+//
+//  Created by Joel Ekström on 2014-10-27.
+//  Copyright (c) 2014 Márton Salomváry. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol SCURLServiceDelegate;
+
+@interface SCURLService : NSObject
+
+- (void)openURL:(NSPasteboard *)pboard userData:(NSString *)userData error:(NSString **)error;
+@property (nonatomic, weak) id <SCURLServiceDelegate> delegate;
+
+@end
+
+@protocol SCURLServiceDelegate <NSObject>
+
+- (void)URLService:(SCURLService *)service didReceiveURL:(NSURL *)URL;
+
+@end

--- a/SoundCleod/SCURLService.m
+++ b/SoundCleod/SCURLService.m
@@ -1,0 +1,101 @@
+//
+//  UrlService.m
+//  SoundCleod
+//
+//  Created by Joel Ekström on 2014-10-27.
+//  Copyright (c) 2014 Márton Salomváry. All rights reserved.
+//
+
+#import "SCURLService.h"
+#import "NSURL+SCUtils.h"
+
+@implementation SCURLService
+
+- (void)openURL:(NSPasteboard *)pboard userData:(NSString *)userData error:(NSString **)error {
+
+    NSString *text = [self extractStringsForSupportedTypes:pboard];
+    [pboard clearContents];
+
+    NSArray *allURLs = [self findLinksInText:text];
+
+    if (allURLs == nil) {
+        *error = @"Error: no URL detected.";
+        return;
+    }
+
+    // Find the first SoundCloud URL if any
+    NSURL *targetURL = nil;
+    for (NSURL *URL in allURLs) {
+        if ([URL isSoundCloudURL]) {
+            targetURL = URL;
+            break;
+        }
+    }
+
+    if (!targetURL) {
+        *error = @"Error: No SoundCloud URL detected.";
+        return;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(URLService:didReceiveURL:)]) {
+        [self.delegate URLService:self didReceiveURL:targetURL];
+    }
+}
+
+/**
+ Since NSPasteboard kan contain different types, we need to extract all types
+ supported by soundcleod. For example, if you right click a link on a webpage
+ <a "href=http://www.apple.com">Apple</a> then NSPasteboardTypeString will contain
+ only "Apple", and the actual link will be in the RTF segment.
+ */
+- (NSString *)extractStringsForSupportedTypes:(NSPasteboard *)pboard
+{
+    NSMutableString *text = [NSMutableString new];
+
+    if ([pboard stringForType:NSPasteboardTypeString]) {
+        [text appendString:[pboard stringForType:NSPasteboardTypeString]];
+    }
+
+    if ([pboard stringForType:NSPasteboardTypeRTF]) {
+        [text appendString:[pboard stringForType:NSPasteboardTypeRTF]];
+    }
+
+    if ([pboard stringForType:NSPasteboardTypeHTML]) {
+        [text appendString:[pboard stringForType:NSPasteboardTypeHTML]];
+    }
+
+    if ([pboard stringForType:NSPasteboardTypeRTFD]) {
+        [text appendString:[pboard stringForType:NSPasteboardTypeRTFD]];
+    }
+
+    if (text.length > 0) {
+        return [text copy];
+    }
+
+    return nil;
+}
+
+- (NSArray *)findLinksInText:(NSString *)text
+{
+    if (!text) {
+        return nil;
+    }
+
+    NSError *error = nil;
+    NSDataDetector *dataDetector = [[NSDataDetector alloc] initWithTypes:NSTextCheckingTypeLink error:&error];
+    NSArray *matches = [dataDetector matchesInString:text options:NULL range:NSMakeRange(0, text.length)];
+
+    NSMutableArray *urls = [NSMutableArray new];
+    for (NSTextCheckingResult *result in matches) {
+        NSURL *URL = result.URL;
+        [urls addObject:URL];
+    }
+
+    if (urls.count == 0) {
+        return nil;
+    }
+
+    return urls;
+}
+
+@end

--- a/SoundCleod/SoundCleod-Info.plist
+++ b/SoundCleod/SoundCleod-Info.plist
@@ -45,6 +45,29 @@
 	<string>SCDApplication</string>
 	<key>SUFeedURL</key>
 	<string>https://raw.github.com/salomvary/soundcleod/master/appcast.xml</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSPortName</key>
+			<string>SoundCleod</string>
+			<key>NSMessage</key>
+			<string>openURL</string>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Open in SoundCleod</string>
+			</dict>
+			<key>NSRequiredContext</key>
+			<dict/>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+				<string>NSRTFPboardType</string>
+				<string>NSHTMLPboardType</string>
+				<string>NSRTFDPboardType</string>
+			</array>
+		</dict>
+	</array>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 </dict>


### PR DESCRIPTION
This PR adds a service for right click support to open SoundCloud URLs from any application in SoundCleod.

Right click a link/text containing URLs -> Click `Services` -> Click `Open in SoundCleod`. You can also assign a keyboard shortcut to open the selected object in SoundCleod through the system settings.

Solves #46 

## Testing notes
* Services for newly installed apps are loaded when logging in to OS X, so after building the first time, one must log out and in once for the service to appear.

* If an application has a custom right click menu, it might not show Services (An example of this is Sublime Text.) You can always access the services by clicking the application name in the status bar, however.

## Issues
* When registering the service I use the "old" values for [Send Types](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/SysServices/Articles/properties.html) (`NSStringPboardType` etc). The [NSPasteboard documentation](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSPasteboard_Class/index.html#//apple_ref/doc/constant_group/Types_for_Standard_Data_OS_X_v10.6_and_later_) states that since OS X 10.6 we should use the new values (`NSPasteboardTypeString` etc) instead, but I was unable to get this to work. The old way seems to work fine for now. If anyone else wants to experiment with this, please go ahead :)

* The service will show up in SoundCleod too, but won't actually do anything. I don't think it's worth spending too much time on since it won't be needed within the app.

## Other notes 
This PR probably renders the cleod://-scheme obsolete. We should consider removing it unless we intend for other apps to be able to communicate with SoundCleod in the future.