### PR TITLE
Workaround Yosemite scrolling issues (#55)

### DIFF
--- a/SoundCleod/AppDelegate.m
+++ b/SoundCleod/AppDelegate.m
@@ -153,6 +153,7 @@ NSString *const SCNavigateJS = @"history.replaceState(null, null, '%@');e=new Ev
     [_webView setUIDelegate:self];
     [_webView setFrameLoadDelegate:self];
     [_webView setPolicyDelegate:self];
+    [_webView setWantsLayer:YES];
 
     [_urlPromptController setNavigateDelegate:self];
     


### PR DESCRIPTION
I've been able to easily reproduce the error on master but after applying this fix I haven't seen the glitch appear.  Ideally this can be removed once the bug in webkit is fixed.

Thanks to @scosman for actually coming up with the solution.

Source: https://bugs.webkit.org/show_bug.cgi?id=137851#c2
