### PR TITLE
Fix for black-screen glitch when exiting fullscreen app on MacOS

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -100,6 +100,22 @@ app.on('ready', function() {
     }
   })
 
+  // For MacOS, disable 'close' and 'minimize' buttons on fullscreen event
+  mainWindow.on('enter-full-screen', (e, cmd) => {
+    if (process.platform == 'darwin') {
+      mainWindow.setMinimizable(false);
+      mainWindow.setClosable(false);
+    }
+  })
+
+  // For MacOS, enable 'close' and 'minimize' buttons on exit-fullscreen event
+  mainWindow.on('leave-full-screen', (e, cmd) => {
+    if (process.platform == 'darwin') {
+      mainWindow.setMinimizable(true);
+      mainWindow.setClosable(true);
+    }
+  })
+
   mainWindow.on('closed', function() {
     if (process.platform !== 'darwin')
       app.quit()

--- a/package.json
+++ b/package.json
@@ -45,14 +45,14 @@
     }
   },
   "devDependencies": {
-    "electron": "1.4.14",
-    "electron-builder": "11.2.5",
-    "electron-builder-squirrel-windows": "11.2.5",
+    "electron": "1.4.15",
+    "electron-builder": "13.8.0",
+    "electron-builder-squirrel-windows": "13.6.1",
     "eslint": "^3.5.0",
     "mocha": "^3.1.2",
     "spectron": "^3.4.0",
     "svg2png": "^4.1.1",
-    "tmp": "0.0.29",
+    "tmp": "0.0.31",
     "to-ico-cli": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hi Márton,
I'm a huge fan of this project! I use it all the time to listen to my music. Unfortunately, there's a small but annoying bug on MacOS, I've provided a simple fix for it.


## The Problem
When closing the SoundCleod app while it is in fullscreen mode on MacOS, the screen turns black and the user can no longer interact with the program.

## The Solution
I've added some code to check whether the app is in fullscreen and on MacOS, and if it is, the screen is minimized before closing. This prevents the black-screen glitch.
```node
// Handle MacOS fullscreen exit glitch
if (process.platform == 'darwin') {
    if (mainWindow.isFullScreen()) {
        mainWindow.setFullScreen(false);
    }
}
// Finish closing procedures
```

---

### Side note
I've only tested this solution on MacOS. I recommend making sure that this is compatible with Windows before merging. I don't think there will be any conflicts or glitches, but better safe then sorry!

Mainly, just make sure the program can close properly when you hit the exit button on Windows.

