### PR TITLE
Rapidly clicking timeline no longer fires 'Play' events incessantly

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -192,7 +192,7 @@ app.on('ready', () => {
     soundcloud.pause()
   })
 
-  soundcloud.on('play', ({ title, subtitle, artworkURL }) => {
+  soundcloud.on('new-track', ({ title, subtitle, artworkURL }) => {
     mainWindow.webContents.send('notification', { title, body: subtitle, icon: artworkURL })
   })
 

--- a/app/main.js
+++ b/app/main.js
@@ -192,7 +192,7 @@ app.on('ready', () => {
     soundcloud.pause()
   })
 
-  soundcloud.on('new-track', ({ title, subtitle, artworkURL }) => {
+  soundcloud.on('play-new-track', ({ title, subtitle, artworkURL }) => {
     mainWindow.webContents.send('notification', { title, body: subtitle, icon: artworkURL })
   })
 

--- a/app/soundcloud.js
+++ b/app/soundcloud.js
@@ -78,7 +78,7 @@ function onMediaStartedPlaying() {
     if (trackMetadata)
       this.emit('play', trackMetadata)
       if (!compareTrackMetadata(this.trackMetadata, trackMetadata)) {
-        this.emit('new-track', trackMetadata)
+        this.emit('play-new-track', trackMetadata)
         this.trackMetadata = trackMetadata
       }
   })

--- a/app/soundcloud.js
+++ b/app/soundcloud.js
@@ -8,6 +8,7 @@ module.exports = class SoundCloud extends Events {
     super()
     this.window = window
     this.playing = false
+    this.trackMetadata = {}
     window.webContents
       .on('media-started-playing', onMediaStartedPlaying.bind(this))
       .on('media-paused', onMediaPaused.bind(this))
@@ -76,6 +77,10 @@ function onMediaStartedPlaying() {
   getTrackMetadata.call(this).then((trackMetadata) => {
     if (trackMetadata)
       this.emit('play', trackMetadata)
+      if (!compareTrackMetadata(this.trackMetadata, trackMetadata)) {
+        this.emit('new-track', trackMetadata)
+        this.trackMetadata = trackMetadata
+      }
   })
 }
 
@@ -128,4 +133,10 @@ function fixFlakyMediaKeys(mainWindow) {
       keyCode: '|'
     })
   })
+}
+
+function compareTrackMetadata(lhs, rhs) {
+  return lhs.title == rhs.title &&
+         lhs.subtitle == rhs.subtitle &&
+         lhs.artworkUrl == rhs.artworkUrl
 }


### PR DESCRIPTION
This fixes spammy notifications when the user clicks on the timeline. It revolves around a new event that fires when a new track plays. Listening to this event in main.js now fires the notification.

One thing of note is that this no longer fires a notification when the user pauses or plays. This can be fixed by starting a timer and firing the notification if the duration of the pause is long enough.