### PR TITLE
Remove Streamcloud from Alternative since it's discontinued.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,7 +58,6 @@ To play SoundCloud:
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) (Mac)
 - [Soundnode App](http://www.soundnodeapp.com/) (Mac, Win, Linux)
 - [Cumulus](https://github.com/gillesdemey/Cumulus) (Mac)
-- [StreamCloud](http://streamcloud.cc) (Mac)
 - [Vox](http://coppertino.com/) (Mac)
 
 ## Forks Using SoundCleod "Engine"


### PR DESCRIPTION
Last commit was in 2016 and website is not reachable.