### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ Current version is 2.0.0 (May 19, 2020) [see changes](https://github.com/salomva
 ### Using [Homebrew Cask](https://formulae.brew.sh/cask/)?
 
 ```sh
-brew cask install soundcleod
+brew install --cask soundcleod
 ```
 
 Note: the homebrew method is supported by the [Caskroom team](https://github.com/caskroom/homebrew-cask), please [report installation issues](https://github.com/caskroom/homebrew-cask#reporting-bugs) there.


### PR DESCRIPTION
Fix error when installing using latest Homebrew(2.7.0). This is not a bug of this app, but README needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103197515-7deb6e00-4929-11eb-9a7b-f813ee1ea952.png)

